### PR TITLE
DiscoverCard Shadow Clipping

### DIFF
--- a/lib/screens/seeker-screens/Newexplore.dart
+++ b/lib/screens/seeker-screens/Newexplore.dart
@@ -39,16 +39,16 @@ class NewExplore extends StatelessWidget {
             children: <Widget>[
               Container(
                 child: DiscoverCard('assets/images/retail.jpg', "Retail", retailJobs),
-                padding: EdgeInsets.fromLTRB(10, 10, 10, 10),
+                padding: EdgeInsets.fromLTRB(2.5, 10, 2.5, 10),
               ),
               Container(
                 child: DiscoverCard(
                     'assets/images/BrickLayer.jpg', "Construction", constructionJobs), 
-                padding: EdgeInsets.fromLTRB(10, 10, 10, 10),
+                padding: EdgeInsets.fromLTRB(2.5, 10, 2.5, 10),
               ),
               Container(
                 child: DiscoverCard('assets/images/cleaning.jpg', "Janitorial", janitorialJobs),
-                padding: EdgeInsets.fromLTRB(10, 10, 10, 10),
+                padding: EdgeInsets.fromLTRB(2.5, 10, 2.5, 10),
               ),
             ],
           )),

--- a/lib/screens/widgets/discoverCard.dart
+++ b/lib/screens/widgets/discoverCard.dart
@@ -18,7 +18,7 @@ class DiscoverCard extends StatelessWidget {
       ),
       
       child: Card(
-        elevation: 10,
+        elevation: 5,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
         child: Column(children: <Widget>[
           ClipRRect(

--- a/lib/screens/widgets/discoverCard.dart
+++ b/lib/screens/widgets/discoverCard.dart
@@ -28,6 +28,7 @@ class DiscoverCard extends StatelessWidget {
                 image: new AssetImage(image),
                 width: 150,
                 height: 100,
+                
                 fit: BoxFit.cover,
               )),
           Container(

--- a/lib/screens/widgets/topJob.dart
+++ b/lib/screens/widgets/topJob.dart
@@ -3,7 +3,6 @@ import 'package:main/screens/widgets/details.dart';
 import './data.dart';
 
 class TopJob extends StatelessWidget {
-
   final String image;
   final String heading;
   final String salary;
@@ -12,51 +11,80 @@ class TopJob extends StatelessWidget {
 
   TopJob(this.image, this.heading, this.salary, this.description, this.job);
 
-
   @override
-  Widget build(BuildContext context){
-    return(
-      GestureDetector(
+  Widget build(BuildContext context) {
+    return (GestureDetector(
         onTap: () => Navigator.push(
-        context,
-        MaterialPageRoute(
-            builder: (context) => new Container(child: DetailPage(job))),
-        ),
-      
-      child: Container(
-        child: Column(
-          children: <Widget>[
-            ClipRRect(borderRadius: BorderRadius.only( topLeft: Radius.circular(20), topRight: Radius.circular(20) ),child: Image(image: new AssetImage(image), width: MediaQuery.of(context).size.width * 0.45, height: 150, fit: BoxFit.cover, )),
-            Container(
-              width: MediaQuery.of(context).size.width * 0.45,
-              height: 150,
-              child: Column(children: <Widget>[
-                Container(height: 10,),
-                Container(child: Text(job.name, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20,), textAlign: TextAlign.left,), width: MediaQuery.of(context).size.width * 0.40, height: 30,),
-                Container(child: Text((job.salary).substring(0, job.salary.length), style: TextStyle(fontWeight: FontWeight.w100, color: Colors.grey), textAlign: TextAlign.left,), width: MediaQuery.of(context).size.width * 0.40, height: 40),
-                Container(child: Text(job.description, style: TextStyle( color: Colors.black), textAlign: TextAlign.left,), width: MediaQuery.of(context).size.width * 0.40,),
-              ],),
+              context,
+              MaterialPageRoute(
+                  builder: (context) => new Container(child: DetailPage(job))),
+            ),
+        child: Card(
+            child: Column(children: <Widget>[
+              ClipRRect(
+                  borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(20),
+                      topRight: Radius.circular(20)),
+                  child: Image(
+                    image: new AssetImage(image),
+                    width: MediaQuery.of(context).size.width * 0.45,
+                    height: 150,
+                    fit: BoxFit.cover,
+                  )),
+              Container(
+                width: MediaQuery.of(context).size.width * 0.45,
+                height: 150,
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                      height: 10,
+                    ),
+                    Container(
+                      child: Text(
+                        job.name,
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 20,
+                        ),
+                        textAlign: TextAlign.left,
+                      ),
+                      width: MediaQuery.of(context).size.width * 0.40,
+                      height: 30,
+                    ),
+                    Container(
+                        child: Text(
+                          (job.salary).substring(0, job.salary.length),
+                          style: TextStyle(
+                              fontWeight: FontWeight.w100, color: Colors.grey),
+                          textAlign: TextAlign.left,
+                        ),
+                        width: MediaQuery.of(context).size.width * 0.40,
+                        height: 40),
+                    Container(
+                      child: Text(
+                        job.description,
+                        style: TextStyle(color: Colors.black),
+                        textAlign: TextAlign.left,
+                      ),
+                      width: MediaQuery.of(context).size.width * 0.40,
+                    ),
+                  ],
+                ),
                 decoration: new BoxDecoration(
                   shape: BoxShape.rectangle,
                   color: Colors.white,
                   borderRadius: new BorderRadius.only(
-                    bottomLeft: Radius.circular(10),
-                    bottomRight: Radius.circular(10)  
-                  ),
-                  boxShadow: [
-                    new BoxShadow(
-                      color: Colors.grey,
-                      offset: new Offset(1.0, 00.0),
-                      blurRadius: 5.0,
-                      spreadRadius: 1,
-                    )
-                  ]
+                      bottomLeft: Radius.circular(20),
+                      bottomRight: Radius.circular(20)),
                 ),
               )
-          ]
-        ),
-      )
-      )
-    );
+            ]),
+            elevation: 10,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(25.0),
+            )
+          )
+        )
+      );
   }
 }


### PR DESCRIPTION
**Summary**

Card elevation for Discover Cards were too high, causing clipping at edge of list view. Top job cards only had shadow for text container, not the entire card.

Fixes #

Fixed elevation from 10 to 5, to remove clipping of shadow. Also added Card as parent to Top job card widget and added elevation for consistent full shadow.

Fix Implementation #

![image](https://user-images.githubusercontent.com/54417453/80159783-d77ceb00-8599-11ea-8107-a0e55c1b818c.png)
