### PR TITLE
fixed error, by fixing loop

### DIFF
--- a/lib/screens/seeker-screens/explore.dart
+++ b/lib/screens/seeker-screens/explore.dart
@@ -35,9 +35,11 @@ class _ExploreState extends State<Explore> {
     }
 
     List<Widget> _createChildren() {
-      return new List<Widget>.generate(4, (int index) {
-        return TopJob(jobDocs[index]);
-      });
+      List<Widget> topJobs = [];
+      for (int i = 0; i < (jobDocs.length >= 4 ? 4 : jobDocs.length); i++){
+        topJobs.add(TopJob(jobDocs[i]));
+      }
+      return topJobs;
     }
 
     List<Widget> _topJobs = new List<Widget>();


### PR DESCRIPTION
**Summary**

An index was going out of bounds causing an error when trying to render the top job cards.

Fixes #

Previously the loop was iterating 4 times, when at the beginning there weren't 4 jobs in the database. I fixed the loop to iterate 4 times only if there were more than 4 jobs. Else it would iterate the number of jobs there were in the database.

![image](https://user-images.githubusercontent.com/54417453/80317094-ccab9b80-87cf-11ea-892c-be4c75afef02.png)
