### PR TITLE
Set Category Images

### DIFF
--- a/lib/screens/widgets/data.dart
+++ b/lib/screens/widgets/data.dart
@@ -10,31 +10,31 @@ class Category{
 List<Category> industries = [
   const Category(
     heading: "Caregiving",
-    image: "care"
+    image: "0nkFvdcM-X4"
   ),
   const Category(
     heading: "Janitorial",
-    image: "janitor"
+    image: "Iu6parQAO-U"
   ),
   const Category(
     heading: "Retail",
-    image: "retail"
+    image: "tE6th1h6Bfk"
   ),
   const Category(
     heading: "Labour",
-    image: "manual work"
+    image: "t_rxW1yGpSU"
   ),
   const Category(
     heading: "Construction",
-    image: "construction"
+    image: "Za9oagRJNLM"
   ),
   const Category(
     heading: "Handyman",
-    image: "handyman"
+    image: "WEWTGkPUVT0"
   ),
   const Category(
     heading: "Freelance",
-    image: "freelance"
+    image: "hfk6xOjQlFk"
   ),
 
 ];

--- a/lib/screens/widgets/discover_card.dart
+++ b/lib/screens/widgets/discover_card.dart
@@ -28,7 +28,7 @@ class DiscoverCard extends StatelessWidget {
               borderRadius: BorderRadius.only(
                   topLeft: Radius.circular(20), topRight: Radius.circular(20)),
               child: Image(
-                image: NetworkImage("https://source.unsplash.com/featured/?" + industry.image),
+                image: NetworkImage("https://source.unsplash.com/" + industry.image + "/400x300"),
                 width: 150,
                 height: 100,
                 


### PR DESCRIPTION
**Summary**

Previously, category cards were fetching images with a random keyword. Needed to fixed due to occurrences of irrelevant images.

Fixes #

Replaced key word with manually found ids for approved images. Also fetched using resolution 400x300 for faster speeds. 

![image](https://user-images.githubusercontent.com/54417453/80317668-1cd82d00-87d3-11ea-8f9b-f949e8f107cf.png)
